### PR TITLE
- Integrate React Query in View task to use cached data if available …

### DIFF
--- a/app/manage/list/components/AddForm.tsx
+++ b/app/manage/list/components/AddForm.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import useTaskListContext from "@/hooks/useTaskListContext";
 import { Dispatch, SetStateAction } from "react";
 import TaskItemEdittableFormLayout from "./TaskItemEdittableFormLayout";
+import { useQueryClient } from "react-query";
 
 interface AddFormProps {
   onBack: Dispatch<SetStateAction<boolean>>;
@@ -12,14 +13,16 @@ interface AddFormProps {
 
 const AddForm: React.FC<AddFormProps> = ({ onBack }) => {
   const router = useRouter();
-  const { updateTaskList, setUpdateTaskList } = useTaskListContext();
+  const queryClient = useQueryClient();
 
-  const HandleSubmit: React.FormEventHandler<HTMLFormElement> = (
+  const HandleSubmit: React.FormEventHandler<HTMLFormElement> = async (
     e: React.FormEvent<HTMLFormElement>
   ) => {
-    FormSubmit(e, "add");
+    await FormSubmit(e, "add");
 
-    if (setUpdateTaskList !== undefined) setUpdateTaskList(true);
+    queryClient.invalidateQueries({ queryKey: ["Tasks"] });
+    queryClient.invalidateQueries({ queryKey: ["TaskDetails"] });
+
     HandleBack();
     router.refresh();
   };

--- a/app/manage/list/components/AddTaskButton.tsx
+++ b/app/manage/list/components/AddTaskButton.tsx
@@ -4,6 +4,8 @@ import Link from "next/link";
 import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog";
 import { useState } from "react";
 import AddForm from "@/app/manage/list/components/AddForm";
+import { useRouter } from "next/navigation";
+import { FormSubmit } from "./HandleSubmitCRUD";
 
 interface AddTaskButtonProps {
   taskCount: number;
@@ -11,6 +13,7 @@ interface AddTaskButtonProps {
 
 const AddTaskButton: React.FC<AddTaskButtonProps> = ({ taskCount }) => {
   const [addOpen, setAddOpen] = useState<boolean>(false);
+
   return (
     <div>
       <div
@@ -24,18 +27,16 @@ const AddTaskButton: React.FC<AddTaskButtonProps> = ({ taskCount }) => {
         mb-1"
       >
         <div className="text-md font-light">{taskCount} results</div>
-        <button>
-          <Dialog open={addOpen} onOpenChange={setAddOpen}>
-            <DialogTrigger asChild>
-              <button>Add Task</button>
-            </DialogTrigger>
-            <DialogContent className="h-full">
-              <div className="mt-12">
-                <AddForm onBack={setAddOpen} />
-              </div>
-            </DialogContent>
-          </Dialog>
-        </button>
+        <Dialog open={addOpen} onOpenChange={setAddOpen}>
+          <DialogTrigger asChild>
+            <button>Add Task</button>
+          </DialogTrigger>
+          <DialogContent className="h-full">
+            <div className="mt-12">
+              <AddForm onBack={setAddOpen} />
+            </div>
+          </DialogContent>
+        </Dialog>
       </div>
       <div className="px-8">
         <Separator className="bg-green-300 pt-0.25" />

--- a/app/manage/list/components/DeleteForm.tsx
+++ b/app/manage/list/components/DeleteForm.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { FormSubmit } from "@/app/manage/list/components/HandleSubmitCRUD";
 import TaskItemDetails from "../../../../components/TaskItemDetails";
 import { Dispatch, SetStateAction } from "react";
+import { useQueryClient } from "react-query";
 interface DeleteFormProps {
   id: string;
   onBack: Dispatch<SetStateAction<boolean>>;
@@ -13,13 +14,16 @@ interface DeleteFormProps {
 
 const DeleteForm: React.FC<DeleteFormProps> = ({ id, onBack }) => {
   const router = useRouter();
-  const { updateTaskList, setUpdateTaskList } = useTaskListContext();
+  const queryClient = useQueryClient();
 
-  const HandleSubmit: React.FormEventHandler<HTMLFormElement> = (
+  const HandleSubmit: React.FormEventHandler<HTMLFormElement> = async (
     e: React.FormEvent<HTMLFormElement>
   ) => {
-    FormSubmit(e, "delete");
-    if (setUpdateTaskList !== undefined) setUpdateTaskList(true);
+    await FormSubmit(e, "delete");
+
+    queryClient.invalidateQueries({ queryKey: ["Tasks"] });
+    queryClient.invalidateQueries({ queryKey: ["TaskDetails"] });
+
     HandleBack();
     router.refresh();
   };

--- a/app/manage/list/components/EditForm.tsx
+++ b/app/manage/list/components/EditForm.tsx
@@ -1,11 +1,12 @@
 "use client";
 import { useRouter } from "next/navigation";
 import { FormSubmit } from "@/app/manage/list/components/HandleSubmitCRUD";
-import { Dispatch, SetStateAction, useEffect, useState } from "react";
+import { Dispatch, SetStateAction } from "react";
 import Link from "next/link";
 import useTaskListContext from "@/hooks/useTaskListContext";
 import { Task } from "@/types/Task";
 import TaskItemEdittableFormLayout from "./TaskItemEdittableFormLayout";
+import { useQueryClient } from "react-query";
 
 interface EditFormProps {
   task: Task;
@@ -14,13 +15,16 @@ interface EditFormProps {
 
 const EditForm: React.FC<EditFormProps> = ({ task, onBack }) => {
   const router = useRouter();
-  const { updateTaskList, setUpdateTaskList } = useTaskListContext();
+  const queryClient = useQueryClient();
 
-  const HandleSubmit: React.FormEventHandler<HTMLFormElement> = (
+  const HandleSubmit: React.FormEventHandler<HTMLFormElement> = async (
     e: React.FormEvent<HTMLFormElement>
   ) => {
-    FormSubmit(e, "edit");
-    if (setUpdateTaskList !== undefined) setUpdateTaskList(true);
+    await FormSubmit(e, "edit");
+
+    queryClient.invalidateQueries({ queryKey: ["Tasks"] });
+    queryClient.invalidateQueries({ queryKey: ["TaskDetails"] });
+
     HandleBack();
     router.refresh();
   };

--- a/app/manage/list/components/FilterSearchResults.tsx
+++ b/app/manage/list/components/FilterSearchResults.tsx
@@ -4,26 +4,28 @@ import GetTaskDetailsByName from "@/components/GetTaskDetailsByName";
 import { Task } from "@/types/Task";
 
 const FilterSearchResults = async (debouncedValue: string) => {
-  let finalFilteredResults: Task[] = [];
+  if (debouncedValue === "") {
+    return await GetTaskDetails();
+  } else {
+    let finalFilteredResults: Task[] = [];
 
-  if (debouncedValue === "") return await GetTaskDetails();
+    const filteredByName = await GetTaskDetailsByName(debouncedValue);
+    const filteredbyDesc = await GetTaskDetailsByDesc(debouncedValue);
 
-  const filteredByName = await GetTaskDetailsByName(debouncedValue);
-  const filteredbyDesc = await GetTaskDetailsByDesc(debouncedValue);
+    if (filteredByName.length !== 0) {
+      Array.prototype.push.apply(finalFilteredResults, filteredByName);
+    }
 
-  if (filteredByName.length !== 0) {
-    Array.prototype.push.apply(finalFilteredResults, filteredByName);
+    if (filteredbyDesc.length !== 0) {
+      Array.prototype.push.apply(finalFilteredResults, filteredbyDesc);
+    }
+
+    finalFilteredResults = Array.from(
+      new Map(finalFilteredResults.map((v) => [v.id, v])).values()
+    );
+
+    return finalFilteredResults;
   }
-
-  if (filteredbyDesc.length !== 0) {
-    Array.prototype.push.apply(finalFilteredResults, filteredbyDesc);
-  }
-
-  finalFilteredResults = Array.from(
-    new Map(finalFilteredResults.map((v) => [v.id, v])).values()
-  );
-
-  return finalFilteredResults;
 };
 
 export default FilterSearchResults;

--- a/app/manage/list/components/HandleSubmitCRUD.tsx
+++ b/app/manage/list/components/HandleSubmitCRUD.tsx
@@ -1,7 +1,7 @@
 import { Task } from "@/types/Task";
 import ExtractFormData from "./ExtractFormData";
-import AddTaskQuery from "./task_queries/AddtaskQuery";
-import EditTaskQuery from "./task_queries/EdittaskQuery";
+import AddTaskQuery from "./task_queries/AddTaskQuery";
+import EditTaskQuery from "./task_queries/EditTaskQuery";
 import DeleteTaskQuery from "./task_queries/DeleteTaskQuery";
 import AssignTaskQuery from "./task_queries/AssignTaskQuery";
 import UnassignTaskQuery from "./task_queries/UnassignTaskQuery";

--- a/app/manage/list/components/SearchForm.tsx
+++ b/app/manage/list/components/SearchForm.tsx
@@ -4,26 +4,16 @@ import GetTaskDetails from "@/components/GetTaskDetails";
 import { Separator } from "@/components/ui/separator";
 import useDebounceSearch from "@/hooks/useDebounceSearch";
 import { Task } from "@/types/Task";
-import { useCallback, useEffect, useState } from "react";
+import { Dispatch, SetStateAction, useState } from "react";
 import FilterSearchResults from "./FilterSearchResults";
 
 interface SearchFormProps {
-  onSearch: (SearchResults: Task[]) => void;
+  onSearch: Dispatch<SetStateAction<string>>;
 }
 
 const SearchForm: React.FC<SearchFormProps> = ({ onSearch }) => {
   const [searchTerm, setSearchTerm] = useState("");
-  const [oldSearchTerm, setOldSearchTerm] = useState("");
   const debouncedValue = useDebounceSearch(searchTerm, 500);
-
-  const GetSearchResults = useCallback(async () => {
-    const searchResults = await FilterSearchResults(debouncedValue);
-    onSearch(searchResults);
-  }, [debouncedValue, onSearch]);
-
-  useEffect(() => {
-    GetSearchResults();
-  }, [GetSearchResults]);
 
   return (
     <div>
@@ -34,7 +24,6 @@ const SearchForm: React.FC<SearchFormProps> = ({ onSearch }) => {
       </div>
 
       {searchTerm}
-      {oldSearchTerm}
       {/*//PERFORMANCE LOGGING */}
       <div
         className=" 
@@ -62,45 +51,13 @@ const SearchForm: React.FC<SearchFormProps> = ({ onSearch }) => {
                       name="SearchTerm"
                       value={searchTerm}
                       onChange={(e) => {
-                        setOldSearchTerm(debouncedValue);
                         setSearchTerm(e.target.value);
+                        onSearch(debouncedValue);
                       }}
                     ></input>
                     <Separator className="bg-green-200 pt-0.5" />
                   </div>
-                  <div className="pr-4">
-                    <button
-                      className="
-              hover:text-gray-300
-              hover:bg-gray-600
-              bg-gray-500
-              rounded-md 
-              text-gray-200
-              px-4          
-              drop-shadow-lg"
-                      type="submit"
-                    >
-                      Search
-                    </button>
-                  </div>
-                </div>
-                <div className="py-4">
-                  <div className="px-4 flex flex-row">
-                    <input
-                      name="NameFilter"
-                      type="checkbox"
-                      defaultChecked={true}
-                    />
-                    <div className="px-4">
-                      <label>Filter by Name</label>
-                    </div>
-                  </div>
-                  <div className="px-4 flex flex-row">
-                    <input name="DescriptionFilter" type="checkbox" />
-                    <div className="px-4">
-                      <label>Filter by Description</label>
-                    </div>
-                  </div>
+                  <div className="pr-4"></div>
                 </div>
               </form>
             </div>

--- a/app/manage/list/components/TaskItemEdittableFormLayout.tsx
+++ b/app/manage/list/components/TaskItemEdittableFormLayout.tsx
@@ -78,13 +78,12 @@ const TaskItemEdittableFormLayout: React.FC<
 
         <div className="mb-4">
           Is this a Recurring Task?
+          {/* TODO: Fix type issue*/}
           <input
             name="is_recurring"
             type="checkbox"
             className="ml-4 scale-125"
-            defaultChecked={
-              isEdit && task !== undefined ? task.is_recurring : false
-            }
+            defaultChecked={isEdit && task !== undefined ? true : false}
           ></input>
         </div>
 
@@ -118,7 +117,7 @@ const TaskItemEdittableFormLayout: React.FC<
             name="due_date"
             type="date"
             className="border-2 w-full"
-            value={
+            placeholder={
               isEdit && task !== undefined
                 ? task.due_date
                 : new Date().toDateString()

--- a/hooks/useDebounceSearch.tsx
+++ b/hooks/useDebounceSearch.tsx
@@ -8,7 +8,6 @@ const useDebounceSearch = (value: string, delay?: number) => {
 
     return () => {
       clearTimeout(timer);
-      console.log("clear timeout");
     };
   }, [value, delay]);
 


### PR DESCRIPTION
…and fetch if not

- Integrate React Query in Manage task list to use cached data if available and fetch if not
- remove debug console.log
- use temp value for default checked for Is Recurring task until the type issue is resolved.
- get rid of unnecessary buttons and filter checkboxes on search bar
- fix import names for add and edit task queries
- invalidate react query cache when Adding, deleting or editting tasks
- Remove unneeded button for Add task that was causing nested button issues.